### PR TITLE
Really minor typo in the doc

### DIFF
--- a/um-doc-main.tex
+++ b/um-doc-main.tex
@@ -699,7 +699,7 @@ Therefore the commands provided by \pkg{unicode-math} should not be compared to 
 \subsubsection{Double-struck}
 
 The double-struck style (also known as `blackboard bold') consists of
-upright Latin letters $\{\symbb{a}$--$\symbb{z}$,$\symbb{A}$$\symbb{Z}\}$,
+upright Latin letters $\{\symbb{a}$--$\symbb{z}$,$\symbb{A}$--$\symbb{Z}\}$,
 numerals $\symbb{0}$--$\symbb{9}$, summation symbol $\symbb\sum$, and four
 Greek letters only: $\{\symbb{\gamma\pi\Gamma\Pi}\}$.
 


### PR DESCRIPTION

A dash was missing between 𝔸 and ℤ in the description of the range of the double-struck style: it was {𝕒–𝕫,𝔸ℤ}
