### PR TITLE
Better support for Arabic math

### DIFF
--- a/testfiles/alph-arabic-literal.luatex.tlg
+++ b/testfiles/alph-arabic-literal.luatex.tlg
@@ -1,0 +1,39 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+ARABIC
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0, direction TLT
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞸀
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞸁
+.\mathoff
+ARABIC INITIAL
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0, direction TLT
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞸢
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞸤
+.\mathoff
+ARABIC TAILED
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0, direction TLT
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞹂
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞹎
+.\mathoff
+ARABIC LOOPED
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0, direction TLT
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞺀
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞺂
+.\mathoff
+ARABIC STRETCHED
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0, direction TLT
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞹡
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𞹢
+.\mathoff
+***************
+Compilation 1 of test file completed with exit status 0

--- a/testfiles/alph-arabic-literal.lvt
+++ b/testfiles/alph-arabic-literal.lvt
@@ -1,0 +1,21 @@
+\input{umtest-preamble}
+\usepackage{unicode-math}
+\setmathfont{XITSMath-Regular.otf}
+\begin{document}
+
+\MSG{ARABIC}
+\SHIPOUT{$𞸀𞸁$}
+
+\MSG{ARABIC INITIAL}
+\SHIPOUT{$𞸢𞸤$}
+
+\MSG{ARABIC TAILED}
+\SHIPOUT{$𞹂𞹎$}
+
+\MSG{ARABIC LOOPED}
+\SHIPOUT{$𞺀𞺂$}
+
+\MSG{ARABIC STRETCHED}
+\SHIPOUT{$𞹡𞹢$}
+
+\end{document}

--- a/testfiles/alph-arabic-literal.tlg
+++ b/testfiles/alph-arabic-literal.tlg
@@ -1,0 +1,39 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+ARABIC
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3420
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3421
+.\mathoff
+ARABIC INITIAL
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3452
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3453
+.\mathoff
+ARABIC TAILED
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3471
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3476
+.\mathoff
+ARABIC LOOPED
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3509
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3511
+.\mathoff
+ARABIC STRETCHED
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3486
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#3487
+.\mathoff
+***************
+Compilation 1 of test file completed with exit status 0

--- a/testfiles/arabic-comma.luatex.tlg
+++ b/testfiles/arabic-comma.luatex.tlg
@@ -1,0 +1,13 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+ARABIC COMMA
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0, direction TLT
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𝑥
+.\TU/XITSMath-Regular.otf(1)/m/n/10 ،
+.\glue(\thinmuskip) 1.66663
+.\TU/XITSMath-Regular.otf(1)/m/n/10 𝑦
+.\mathoff
+***************
+Compilation 1 of test file completed with exit status 0

--- a/testfiles/arabic-comma.lvt
+++ b/testfiles/arabic-comma.lvt
@@ -1,0 +1,9 @@
+\input{umtest-preamble}
+\usepackage{unicode-math}
+\setmathfont{XITSMath-Regular.otf}
+\begin{document}
+
+\MSG{ARABIC COMMA}
+\SHIPOUT{$x،y$}
+
+\end{document}

--- a/testfiles/arabic-comma.tlg
+++ b/testfiles/arabic-comma.tlg
@@ -1,0 +1,13 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+ARABIC COMMA
+Completed box being shipped out [2]
+\hbox(0.0+0.0)x0.0
+.\mathon
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#2524
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#819
+.\glue(\thinmuskip) 1.66681
+.\TU/XITSMath-Regular.otf(1)/m/n/10 glyph#2525
+.\mathoff
+***************
+Compilation 1 of test file completed with exit status 0

--- a/unicode-math-table.tex
+++ b/unicode-math-table.tex
@@ -1451,6 +1451,7 @@
 \UnicodeMathSymbol{"02B54}{\rightpentagon            }{\mathord}{white right-pointing pentagon}%
 \UnicodeMathSymbol{"03012}{\postalmark               }{\mathord}{postal mark}%
 \UnicodeMathSymbol{"03030}{\hzigzag                  }{\mathord}{zigzag}%
+\UnicodeMathSymbol{"0060C}{\arabiccomma              }{\mathpunct}{arabic comma}%
 \UnicodeMathSymbol{"1D400}{\mbfA                     }{\mathalpha}{mathematical bold capital a}%
 \UnicodeMathSymbol{"1D401}{\mbfB                     }{\mathalpha}{mathematical bold capital b}%
 \UnicodeMathSymbol{"1D402}{\mbfC                     }{\mathalpha}{mathematical bold capital c}%

--- a/unicode-math-table.tex
+++ b/unicode-math-table.tex
@@ -2447,6 +2447,147 @@
 \UnicodeMathSymbol{"1D7FD}{\mttseven                 }{\mathord}{mathematical monospace digit 7}%
 \UnicodeMathSymbol{"1D7FE}{\mtteight                 }{\mathord}{mathematical monospace digit 8}%
 \UnicodeMathSymbol{"1D7FF}{\mttnine                  }{\mathord}{mathematical monospace digit 9}%
+\UnicodeMathSymbol{"1EE00}{\mAlef                    }{\mathalpha}{arabic mathematical alef}%
+\UnicodeMathSymbol{"1EE01}{\mBeh                     }{\mathalpha}{arabic mathematical beh}%
+\UnicodeMathSymbol{"1EE02}{\mJeem                    }{\mathalpha}{arabic mathematical jeem}%
+\UnicodeMathSymbol{"1EE03}{\mDal                     }{\mathalpha}{arabic mathematical dal}%
+\UnicodeMathSymbol{"1EE05}{\mWaw                     }{\mathalpha}{arabic mathematical waw}%
+\UnicodeMathSymbol{"1EE06}{\mZain                    }{\mathalpha}{arabic mathematical zain}%
+\UnicodeMathSymbol{"1EE07}{\mHah                     }{\mathalpha}{arabic mathematical hah}%
+\UnicodeMathSymbol{"1EE08}{\mTah                     }{\mathalpha}{arabic mathematical tah}%
+\UnicodeMathSymbol{"1EE09}{\mYeh                     }{\mathalpha}{arabic mathematical yeh}%
+\UnicodeMathSymbol{"1EE0A}{\mKaf                     }{\mathalpha}{arabic mathematical kaf}%
+\UnicodeMathSymbol{"1EE0B}{\mLam                     }{\mathalpha}{arabic mathematical lam}%
+\UnicodeMathSymbol{"1EE0C}{\mMeem                    }{\mathalpha}{arabic mathematical meem}%
+\UnicodeMathSymbol{"1EE0D}{\mNoon                    }{\mathalpha}{arabic mathematical noon}%
+\UnicodeMathSymbol{"1EE0E}{\mSeen                    }{\mathalpha}{arabic mathematical seen}%
+\UnicodeMathSymbol{"1EE0F}{\mAin                     }{\mathalpha}{arabic mathematical ain}%
+\UnicodeMathSymbol{"1EE10}{\mFeh                     }{\mathalpha}{arabic mathematical feh}%
+\UnicodeMathSymbol{"1EE11}{\mSad                     }{\mathalpha}{arabic mathematical sad}%
+\UnicodeMathSymbol{"1EE12}{\mQaf                     }{\mathalpha}{arabic mathematical qaf}%
+\UnicodeMathSymbol{"1EE13}{\mReh                     }{\mathalpha}{arabic mathematical reh}%
+\UnicodeMathSymbol{"1EE14}{\mSheen                   }{\mathalpha}{arabic mathematical sheen}%
+\UnicodeMathSymbol{"1EE15}{\mTeh                     }{\mathalpha}{arabic mathematical teh}%
+\UnicodeMathSymbol{"1EE16}{\mTheh                    }{\mathalpha}{arabic mathematical theh}%
+\UnicodeMathSymbol{"1EE17}{\mKhah                    }{\mathalpha}{arabic mathematical khah}%
+\UnicodeMathSymbol{"1EE18}{\mThal                    }{\mathalpha}{arabic mathematical thal}%
+\UnicodeMathSymbol{"1EE19}{\mDad                     }{\mathalpha}{arabic mathematical dad}%
+\UnicodeMathSymbol{"1EE1A}{\mZah                     }{\mathalpha}{arabic mathematical zah}%
+\UnicodeMathSymbol{"1EE1B}{\mGhain                   }{\mathalpha}{arabic mathematical ghain}%
+\UnicodeMathSymbol{"1EE1C}{\mDotlessBeh              }{\mathalpha}{arabic mathematical dotless beh}%
+\UnicodeMathSymbol{"1EE1D}{\mDotlessNoon             }{\mathalpha}{arabic mathematical dotless noon}%
+\UnicodeMathSymbol{"1EE1E}{\mDotlessFeh              }{\mathalpha}{arabic mathematical dotless feh}%
+\UnicodeMathSymbol{"1EE1F}{\mDotlessQaf              }{\mathalpha}{arabic mathematical dotless qaf}%
+\UnicodeMathSymbol{"1EE21}{\minitialBeh              }{\mathalpha}{arabic mathematical initial beh}%
+\UnicodeMathSymbol{"1EE22}{\minitialJeem             }{\mathalpha}{arabic mathematical initial jeem}%
+\UnicodeMathSymbol{"1EE24}{\minitialHeh              }{\mathalpha}{arabic mathematical initial heh}%
+\UnicodeMathSymbol{"1EE27}{\minitialHah              }{\mathalpha}{arabic mathematical initial hah}%
+\UnicodeMathSymbol{"1EE29}{\minitialYeh              }{\mathalpha}{arabic mathematical initial yeh}%
+\UnicodeMathSymbol{"1EE2A}{\minitialKaf              }{\mathalpha}{arabic mathematical initial kaf}%
+\UnicodeMathSymbol{"1EE2B}{\minitialLam              }{\mathalpha}{arabic mathematical initial lam}%
+\UnicodeMathSymbol{"1EE2C}{\minitialMeem             }{\mathalpha}{arabic mathematical initial meem}%
+\UnicodeMathSymbol{"1EE2D}{\minitialNoon             }{\mathalpha}{arabic mathematical initial noon}%
+\UnicodeMathSymbol{"1EE2E}{\minitialSeen             }{\mathalpha}{arabic mathematical initial seen}%
+\UnicodeMathSymbol{"1EE2F}{\minitialAin              }{\mathalpha}{arabic mathematical initial ain}%
+\UnicodeMathSymbol{"1EE30}{\minitialFeh              }{\mathalpha}{arabic mathematical initial feh}%
+\UnicodeMathSymbol{"1EE31}{\minitialSad              }{\mathalpha}{arabic mathematical initial sad}%
+\UnicodeMathSymbol{"1EE32}{\minitialQaf              }{\mathalpha}{arabic mathematical initial qaf}%
+\UnicodeMathSymbol{"1EE34}{\minitialSheen            }{\mathalpha}{arabic mathematical initial sheen}%
+\UnicodeMathSymbol{"1EE35}{\minitialTeh              }{\mathalpha}{arabic mathematical initial teh}%
+\UnicodeMathSymbol{"1EE36}{\minitialTheh             }{\mathalpha}{arabic mathematical initial theh}%
+\UnicodeMathSymbol{"1EE37}{\minitialKhah             }{\mathalpha}{arabic mathematical initial khah}%
+\UnicodeMathSymbol{"1EE39}{\minitialDad              }{\mathalpha}{arabic mathematical initial dad}%
+\UnicodeMathSymbol{"1EE3B}{\minitialGhain            }{\mathalpha}{arabic mathematical initial ghain}%
+\UnicodeMathSymbol{"1EE42}{\mtailedJeem              }{\mathalpha}{arabic mathematical tailed jeem}%
+\UnicodeMathSymbol{"1EE47}{\mtailedHah               }{\mathalpha}{arabic mathematical tailed hah}%
+\UnicodeMathSymbol{"1EE49}{\mtailedYeh               }{\mathalpha}{arabic mathematical tailed yeh}%
+\UnicodeMathSymbol{"1EE4B}{\mtailedLam               }{\mathalpha}{arabic mathematical tailed lam}%
+\UnicodeMathSymbol{"1EE4D}{\mtailedNoon              }{\mathalpha}{arabic mathematical tailed noon}%
+\UnicodeMathSymbol{"1EE4E}{\mtailedSeen              }{\mathalpha}{arabic mathematical tailed seen}%
+\UnicodeMathSymbol{"1EE4F}{\mtailedAin               }{\mathalpha}{arabic mathematical tailed ain}%
+\UnicodeMathSymbol{"1EE51}{\mtailedSad               }{\mathalpha}{arabic mathematical tailed sad}%
+\UnicodeMathSymbol{"1EE52}{\mtailedQaf               }{\mathalpha}{arabic mathematical tailed qaf}%
+\UnicodeMathSymbol{"1EE54}{\mtailedSheen             }{\mathalpha}{arabic mathematical tailed sheen}%
+\UnicodeMathSymbol{"1EE57}{\mtailedKhah              }{\mathalpha}{arabic mathematical tailed khah}%
+\UnicodeMathSymbol{"1EE59}{\mtailedDad               }{\mathalpha}{arabic mathematical tailed dad}%
+\UnicodeMathSymbol{"1EE5B}{\mtailedGhain             }{\mathalpha}{arabic mathematical tailed ghain}%
+\UnicodeMathSymbol{"1EE5D}{\mtailedDotlessNoon       }{\mathalpha}{arabic mathematical tailed dotless noon}%
+\UnicodeMathSymbol{"1EE5F}{\mtailedDotlessQaf        }{\mathalpha}{arabic mathematical tailed dotless qaf}%
+\UnicodeMathSymbol{"1EE61}{\mstretchedBeh            }{\mathalpha}{arabic mathematical stretched beh}%
+\UnicodeMathSymbol{"1EE62}{\mstretchedJeem           }{\mathalpha}{arabic mathematical stretched jeem}%
+\UnicodeMathSymbol{"1EE64}{\mstretchedHeh            }{\mathalpha}{arabic mathematical stretched heh}%
+\UnicodeMathSymbol{"1EE67}{\mstretchedHah            }{\mathalpha}{arabic mathematical stretched hah}%
+\UnicodeMathSymbol{"1EE68}{\mstretchedTah            }{\mathalpha}{arabic mathematical stretched tah}%
+\UnicodeMathSymbol{"1EE69}{\mstretchedYeh            }{\mathalpha}{arabic mathematical stretched yeh}%
+\UnicodeMathSymbol{"1EE6A}{\mstretchedKaf            }{\mathalpha}{arabic mathematical stretched kaf}%
+\UnicodeMathSymbol{"1EE6C}{\mstretchedMeem           }{\mathalpha}{arabic mathematical stretched meem}%
+\UnicodeMathSymbol{"1EE6D}{\mstretchedNoon           }{\mathalpha}{arabic mathematical stretched noon}%
+\UnicodeMathSymbol{"1EE6E}{\mstretchedSeen           }{\mathalpha}{arabic mathematical stretched seen}%
+\UnicodeMathSymbol{"1EE6F}{\mstretchedAin            }{\mathalpha}{arabic mathematical stretched ain}%
+\UnicodeMathSymbol{"1EE70}{\mstretchedFeh            }{\mathalpha}{arabic mathematical stretched feh}%
+\UnicodeMathSymbol{"1EE71}{\mstretchedSad            }{\mathalpha}{arabic mathematical stretched sad}%
+\UnicodeMathSymbol{"1EE72}{\mstretchedQaf            }{\mathalpha}{arabic mathematical stretched qaf}%
+\UnicodeMathSymbol{"1EE74}{\mstretchedSheen          }{\mathalpha}{arabic mathematical stretched sheen}%
+\UnicodeMathSymbol{"1EE75}{\mstretchedTeh            }{\mathalpha}{arabic mathematical stretched teh}%
+\UnicodeMathSymbol{"1EE76}{\mstretchedTheh           }{\mathalpha}{arabic mathematical stretched theh}%
+\UnicodeMathSymbol{"1EE77}{\mstretchedKhah           }{\mathalpha}{arabic mathematical stretched khah}%
+\UnicodeMathSymbol{"1EE79}{\mstretchedDad            }{\mathalpha}{arabic mathematical stretched dad}%
+\UnicodeMathSymbol{"1EE7A}{\mstretchedZah            }{\mathalpha}{arabic mathematical stretched zah}%
+\UnicodeMathSymbol{"1EE7B}{\mstretchedGhain          }{\mathalpha}{arabic mathematical stretched ghain}%
+\UnicodeMathSymbol{"1EE7C}{\mstretchedDotlessBeh     }{\mathalpha}{arabic mathematical stretched dotless beh}%
+\UnicodeMathSymbol{"1EE7E}{\mstretchedDotlessFeh     }{\mathalpha}{arabic mathematical stretched dotless feh}%
+\UnicodeMathSymbol{"1EE80}{\mloopedAlef              }{\mathalpha}{arabic mathematical looped alef}%
+\UnicodeMathSymbol{"1EE81}{\mloopedBeh               }{\mathalpha}{arabic mathematical looped beh}%
+\UnicodeMathSymbol{"1EE82}{\mloopedJeem              }{\mathalpha}{arabic mathematical looped jeem}%
+\UnicodeMathSymbol{"1EE83}{\mloopedDal               }{\mathalpha}{arabic mathematical looped dal}%
+\UnicodeMathSymbol{"1EE84}{\mloopedHeh               }{\mathalpha}{arabic mathematical looped heh}%
+\UnicodeMathSymbol{"1EE85}{\mloopedWaw               }{\mathalpha}{arabic mathematical looped waw}%
+\UnicodeMathSymbol{"1EE86}{\mloopedZain              }{\mathalpha}{arabic mathematical looped zain}%
+\UnicodeMathSymbol{"1EE87}{\mloopedHah               }{\mathalpha}{arabic mathematical looped hah}%
+\UnicodeMathSymbol{"1EE88}{\mloopedTah               }{\mathalpha}{arabic mathematical looped tah}%
+\UnicodeMathSymbol{"1EE89}{\mloopedYeh               }{\mathalpha}{arabic mathematical looped yeh}%
+\UnicodeMathSymbol{"1EE8B}{\mloopedLam               }{\mathalpha}{arabic mathematical looped lam}%
+\UnicodeMathSymbol{"1EE8C}{\mloopedMeem              }{\mathalpha}{arabic mathematical looped meem}%
+\UnicodeMathSymbol{"1EE8D}{\mloopedNoon              }{\mathalpha}{arabic mathematical looped noon}%
+\UnicodeMathSymbol{"1EE8E}{\mloopedSeen              }{\mathalpha}{arabic mathematical looped seen}%
+\UnicodeMathSymbol{"1EE8F}{\mloopedAin               }{\mathalpha}{arabic mathematical looped ain}%
+\UnicodeMathSymbol{"1EE90}{\mloopedFeh               }{\mathalpha}{arabic mathematical looped feh}%
+\UnicodeMathSymbol{"1EE91}{\mloopedSad               }{\mathalpha}{arabic mathematical looped sad}%
+\UnicodeMathSymbol{"1EE92}{\mloopedQaf               }{\mathalpha}{arabic mathematical looped qaf}%
+\UnicodeMathSymbol{"1EE93}{\mloopedReh               }{\mathalpha}{arabic mathematical looped reh}%
+\UnicodeMathSymbol{"1EE94}{\mloopedSheen             }{\mathalpha}{arabic mathematical looped sheen}%
+\UnicodeMathSymbol{"1EE95}{\mloopedTeh               }{\mathalpha}{arabic mathematical looped teh}%
+\UnicodeMathSymbol{"1EE96}{\mloopedTheh              }{\mathalpha}{arabic mathematical looped theh}%
+\UnicodeMathSymbol{"1EE97}{\mloopedKhah              }{\mathalpha}{arabic mathematical looped khah}%
+\UnicodeMathSymbol{"1EE98}{\mloopedThal              }{\mathalpha}{arabic mathematical looped thal}%
+\UnicodeMathSymbol{"1EE99}{\mloopedDad               }{\mathalpha}{arabic mathematical looped dad}%
+\UnicodeMathSymbol{"1EE9A}{\mloopedZah               }{\mathalpha}{arabic mathematical looped zah}%
+\UnicodeMathSymbol{"1EE9B}{\mloopedGhain             }{\mathalpha}{arabic mathematical looped ghain}%
+\UnicodeMathSymbol{"1EEA1}{\BbbBeh                   }{\mathalpha}{arabic mathematical double-struck beh}%
+\UnicodeMathSymbol{"1EEA2}{\BbbJeem                  }{\mathalpha}{arabic mathematical double-struck jeem}%
+\UnicodeMathSymbol{"1EEA3}{\BbbDal                   }{\mathalpha}{arabic mathematical double-struck dal}%
+\UnicodeMathSymbol{"1EEA5}{\BbbWaw                   }{\mathalpha}{arabic mathematical double-struck waw}%
+\UnicodeMathSymbol{"1EEA6}{\BbbZain                  }{\mathalpha}{arabic mathematical double-struck zain}%
+\UnicodeMathSymbol{"1EEA7}{\BbbHah                   }{\mathalpha}{arabic mathematical double-struck hah}%
+\UnicodeMathSymbol{"1EEA8}{\BbbTah                   }{\mathalpha}{arabic mathematical double-struck tah}%
+\UnicodeMathSymbol{"1EEA9}{\BbbYeh                   }{\mathalpha}{arabic mathematical double-struck yeh}%
+\UnicodeMathSymbol{"1EEAB}{\BbbLam                   }{\mathalpha}{arabic mathematical double-struck lam}%
+\UnicodeMathSymbol{"1EEAC}{\BbbMeem                  }{\mathalpha}{arabic mathematical double-struck meem}%
+\UnicodeMathSymbol{"1EEAD}{\BbbNoon                  }{\mathalpha}{arabic mathematical double-struck noon}%
+\UnicodeMathSymbol{"1EEAE}{\BbbSeen                  }{\mathalpha}{arabic mathematical double-struck seen}%
+\UnicodeMathSymbol{"1EEAF}{\BbbAin                   }{\mathalpha}{arabic mathematical double-struck ain}%
+\UnicodeMathSymbol{"1EEB0}{\BbbFeh                   }{\mathalpha}{arabic mathematical double-struck feh}%
+\UnicodeMathSymbol{"1EEB1}{\BbbSad                   }{\mathalpha}{arabic mathematical double-struck sad}%
+\UnicodeMathSymbol{"1EEB2}{\BbbQaf                   }{\mathalpha}{arabic mathematical double-struck qaf}%
+\UnicodeMathSymbol{"1EEB3}{\BbbReh                   }{\mathalpha}{arabic mathematical double-struck reh}%
+\UnicodeMathSymbol{"1EEB4}{\BbbSheen                 }{\mathalpha}{arabic mathematical double-struck sheen}%
+\UnicodeMathSymbol{"1EEB5}{\BbbTeh                   }{\mathalpha}{arabic mathematical double-struck teh}%
+\UnicodeMathSymbol{"1EEB6}{\BbbTheh                  }{\mathalpha}{arabic mathematical double-struck theh}%
+\UnicodeMathSymbol{"1EEB7}{\BbbKhah                  }{\mathalpha}{arabic mathematical double-struck khah}%
+\UnicodeMathSymbol{"1EEB8}{\BbbThal                  }{\mathalpha}{arabic mathematical double-struck thal}%
+\UnicodeMathSymbol{"1EEB9}{\BbbDad                   }{\mathalpha}{arabic mathematical double-struck dad}%
+\UnicodeMathSymbol{"1EEBA}{\BbbZah                   }{\mathalpha}{arabic mathematical double-struck zah}%
+\UnicodeMathSymbol{"1EEBB}{\BbbGhain                 }{\mathalpha}{arabic mathematical double-struck ghain}%
 \UnicodeMathSymbol{"1EEF0}{\arabicmaj                }{\mathop}{arabic mathematical operator meem with hah with tatweel}%
 \UnicodeMathSymbol{"1EEF1}{\arabichad                }{\mathop}{arabic mathematical operator hah with dal}%
 
@@ -2462,7 +2603,7 @@
 % Copyright 2006-2019  Will Robertson, LPPL "maintainer"
 % Copyright 2010-2017  Philipp Stephani
 % Copyright 2011-2017  Joseph Wright
-% Copyright 2012-2015  Khaled Hosny
+% Copyright 2012-2023  Khaled Hosny
 % ------------------------------------------------
 %
 % ©/


### PR DESCRIPTION
## Status
**UNDER DEVELOPMENT**

## Description
Improve handling of Arabic math symbols.
1. Allow Arabic math alphabets to be used when `unicode-math` is loaded, previously they would always be using CMMI fonts.
2. Fix spacing of Arabic comma by making sure it gets punctuation math class.

## Todo
- [x] Tests added to cover new/fixed functionality
- [ ] Documentation added if necessary
- [ ] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```tex
\documentclass{article}
\usepackage{unicode-math}
\setmathfont{XITSMath-Regular.otf}
\usepackage{ifluatex}
\begin{document}
\ifluatex\mathdir TRT\fi
\[
  \mAlef + \mBeh = \minitialJeem
\]
\end{document}
```

