### PR TITLE
Add commas to subsubsection titles with “Greek” in unimath-symbols.ltx

### DIFF
--- a/unimath-symbols.ltx
+++ b/unimath-symbols.ltx
@@ -349,10 +349,10 @@ The limits behaviour as specified by \textsf{unicode-math} are shown with grey s
 
 \subsection{Normal weight}
 
-\subsubsection{Upright Greek, uppercase}
+\subsubsection{Upright, Greek, uppercase}
 \SLOTS{"00391}{"003A9}
 
-\subsubsection{Upright Greek, lowercase}
+\subsubsection{Upright, Greek, lowercase}
 \SLOTS{"003B1}{"003F5}
 
 \subsubsection{Italic, Latin, uppercase}
@@ -361,10 +361,10 @@ The limits behaviour as specified by \textsf{unicode-math} are shown with grey s
 \subsubsection{Italic, Latin, lowercase}
 \SLOTS{"1D44E}{"1D467}
 
-\subsubsection{Italic Greek, uppercase}
+\subsubsection{Italic, Greek, uppercase}
 \SLOTS{"1D6E2}{"1D6FA}
 
-\subsubsection{Italic Greek, lowercase}
+\subsubsection{Italic, Greek, lowercase}
 \SLOTS{"1D6FC}{"1D71B}
 
 \subsubsection{Script, Latin, uppercase}
@@ -411,10 +411,10 @@ The limits behaviour as specified by \textsf{unicode-math} are shown with grey s
 \subsubsection{Bold, Latin, lowercase}
 \SLOTS{"1D41A}{"1D433}
 
-\subsubsection{Bold Greek, uppercase}
+\subsubsection{Bold, Greek, uppercase}
 \SLOTS{"1D6A8}{"1D6C0}
 
-\subsubsection{Bold Greek, lowercase}
+\subsubsection{Bold, Greek, lowercase}
 \SLOTS{"1D6C2}{"1D6E1}
 
 \subsubsection{Bold italic, Latin, uppercase}
@@ -423,10 +423,10 @@ The limits behaviour as specified by \textsf{unicode-math} are shown with grey s
 \subsubsection{Bold italic, Latin, lowercase}
 \SLOTS{"1D482}{"1D49B}
 
-\subsubsection{Bold italic Greek, uppercase}
+\subsubsection{Bold italic, Greek, uppercase}
 \SLOTS{"1D71C}{"1D734}
 
-\subsubsection{Bold italic Greek, lowercase}
+\subsubsection{Bold italic, Greek, lowercase}
 \SLOTS{"1D736}{"1D755}
 
 \subsubsection{Bold script, Latin, uppercase}
@@ -453,16 +453,16 @@ The limits behaviour as specified by \textsf{unicode-math} are shown with grey s
 \subsubsection{Bold italic sans serif, Latin, lowercase}
 \SLOTS{"1D656}{"1D66F}
 
-\subsubsection{Bold sans serif Greek, uppercase}
+\subsubsection{Bold sans serif, Greek, uppercase}
 \SLOTS{"1D756}{"1D76E}
 
-\subsubsection{Bold sans serif Greek, lowercase}
+\subsubsection{Bold sans serif, Greek, lowercase}
 \SLOTS{"1D770}{"1D78F}
 
-\subsubsection{Bold italic sans serif Greek, uppercase}
+\subsubsection{Bold italic sans serif, Greek, uppercase}
 \SLOTS{"1D790}{"1D7A8}
 
-\subsubsection{Bold italic sans serif Greek, lowercase}
+\subsubsection{Bold italic sans serif, Greek, lowercase}
 \SLOTS{"1D7AA}{"1D7C9}
 
 \subsection{Miscellaneous}


### PR DESCRIPTION
## Status
**FOR DISCUSSION**

## Description
Only one file is changed in this commitment, that is, `unimath-symbols.ltx`. No functional change is appended to this repository; only a documentation (`texdoc unimath-symbols`) is influenced.

To maintain consistency with other subsubsections, commas are added before the word “Greek” in section titles containing the keyword “Greek”. It will be easier for a user to find information in section 13 (\mathalpha) after this commitment.

## Todo
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation added if necessary
- [ ] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
No new or fixed functionality. `unimath-symbols.ltx` and source files of symbol documentations for other fonts require to be recompiled to generate updated documentations.

